### PR TITLE
feat(contact): wire API to Resend + server validation + rate limit

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,0 +1,3 @@
+RESEND_API_KEY=your_resend_key_here
+CONTACT_FROM_EMAIL=onboarding@resend.dev
+CONTACT_TO_EMAIL=you@example.com

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -1,37 +1,62 @@
-import { NextResponse } from 'next/server';
-import { z } from 'zod';
-import { sendContactEmail } from '@/lib/email';
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { sendContactEmail } from "@/lib/email";
 
+export const runtime = "nodejs"; // supaya in-memory rate limiter bertahan di dev/node runtimes
+
+// Schema server-side (samakan dengan klien)
 const contactSchema = z.object({
-  name: z.string().min(1),
-  email: z.string().email(),
-  message: z.string().min(1),
-  website: z.string().optional().or(z.literal('')), // honeypot
+  name: z.string().trim().min(2).max(100),
+  email: z.string().trim().email(),
+  message: z.string().trim().min(10).max(2000),
+  hp: z.string().optional().default(""),
 });
 
-export async function POST(req: Request) {
-  try {
-    const json = await req.json();
-    const parsed = contactSchema.safeParse(json);
-    if (!parsed.success) {
-      return NextResponse.json({ ok: false, error: 'invalid body' }, { status: 400 });
-    }
+// Rate limit in-memory
+const WINDOW_MS = 60_000; // 60 detik
+const MAX_REQ = 3;        // 3 request per window per IP
+const bucket = new Map<string, { count: number; resetAt: number }>();
 
-    const { name, email, message, website } = parsed.data;
-
-    // Honeypot: kalau terisi, diam-diam drop tapi tetap 200 supaya tidak memberi sinyal ke bot
-    if (website) {
-      return NextResponse.json({ ok: true, sent: false });
-    }
-
-    const { sent } = await sendContactEmail({ name, email, message });
-    return NextResponse.json({ ok: true, sent });
-  } catch {
-    return NextResponse.json({ ok: false }, { status: 400 });
+function allow(ip: string) {
+  const now = Date.now();
+  const node = bucket.get(ip);
+  if (!node || now > node.resetAt) {
+    bucket.set(ip, { count: 1, resetAt: now + WINDOW_MS });
+    return true;
   }
+  if (node.count < MAX_REQ) {
+    node.count += 1;
+    return true;
+  }
+  return false;
 }
 
-// (opsional) simple ping
-export async function GET() {
-  return NextResponse.json({ ok: true });
+export async function POST(req: Request) {
+  const ip = (req.headers.get("x-forwarded-for")?.split(",")[0] ?? "local").trim();
+  if (!allow(ip)) {
+    return NextResponse.json({ ok: false, error: "Too many requests" }, { status: 429 });
+  }
+
+  let payload: unknown;
+  try {
+    payload = await req.json();
+  } catch {
+    return NextResponse.json({ ok: false, error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const parsed = contactSchema.safeParse(payload);
+  if (!parsed.success) {
+    return NextResponse.json({ ok: false, error: "Invalid input", issues: parsed.error.flatten() }, { status: 400 });
+  }
+
+  const { hp, name, email, message } = parsed.data;
+
+  // Jika honeypot terisi, abaikan kirim email (anggap sukses tanpa kirim)
+  if (hp) {
+    return NextResponse.json({ ok: true, sent: false });
+  }
+
+  const result = await sendContactEmail({ name, email, message });
+  return NextResponse.json(result);
 }
+

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -1,46 +1,37 @@
-import { Resend } from 'resend';
+export type ContactEmailParams = { name: string; email: string; message: string };
 
-type Params = { name: string; email: string; message: string };
-
-const FROM = process.env.RESEND_FROM || 'Gigaviz <noreply@gigaviz.com>';
-const TO = process.env.CONTACT_TO || 'admin@gigaviz.com>';
-
-let client: Resend | null = null;
-
-function getClient(): Resend | null {
-  const key = process.env.RESEND_API_KEY;
-  if (!key) return null;
-  try {
-    client = client ?? new Resend(key);
-    return client;
-  } catch {
-    return null;
-  }
-}
-
-export async function sendContactEmail(
-  { name, email, message }: Params
-): Promise<{ sent: boolean }> {
-  const c = getClient();
-  if (!c) {
-    console.warn('[email] RESEND_API_KEY missing or client not initialised.');
-    return { sent: false };
+export async function sendContactEmail({ name, email, message }: ContactEmailParams) {
+  const apiKey = process.env.RESEND_API_KEY;
+  // Fallback saat tidak ada API key
+  if (!apiKey) {
+    return { ok: true as const, sent: false as const };
   }
 
+  const from = process.env.CONTACT_FROM_EMAIL ?? "onboarding@resend.dev";
+  const to = process.env.CONTACT_TO_EMAIL ?? process.env.CONTACT_FROM_EMAIL ?? "you@example.com";
+
   try {
-    await c.emails.send({
-      from: FROM,
-      to: TO,
-      subject: `New contact from ${name}`,
-      text:
-        `Name: ${name}\n` +
-        `Email: ${email}\n\n` +
-        `Message:\n${message}\n`,
-      replyTo: email,
+    const res = await fetch("https://api.resend.com/emails", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        from,
+        to,
+        subject: `New contact message from ${name}`,
+        text: `Name: ${name}\nEmail: ${email}\n\n${message}`,
+        reply_to: email,
+      }),
     });
-    return { sent: true };
-  } catch (err) {
-    console.error('[email] send failed', err);
-    return { sent: false };
+
+    if (!res.ok) {
+      return { ok: true as const, sent: false as const };
+    }
+    return { ok: true as const, sent: true as const };
+  } catch {
+    return { ok: true as const, sent: false as const };
   }
 }
+


### PR DESCRIPTION
## Summary
- send contact emails via Resend REST API with safe fallback when no API key
- validate and rate-limit contact form submissions server-side
- document Resend and contact email settings in `.env.local`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bb458b9a3c8332ae53c3c73f5b9bb7